### PR TITLE
 prefer sys/prctl.h over linux/prctl.h

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -7,13 +7,13 @@
 #include <linux/ipc.h>
 #include <linux/net.h>
 #include <linux/perf_event.h>
-#include <linux/prctl.h>
 #include <linux/unistd.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/personality.h>
+#include <sys/prctl.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/time.h>

--- a/src/util.cc
+++ b/src/util.cc
@@ -13,13 +13,13 @@
 #include <limits.h>
 #include <linux/capability.h>
 #include <linux/magic.h>
-#include <linux/prctl.h>
 #include <math.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
+#include <sys/prctl.h>
 #include <sys/socket.h>
 #include <sys/syscall.h>
 #include <sys/time.h>


### PR DESCRIPTION
as the first may be included in other headers and both may conflict