### PR TITLE
portability for scm_rights using cast and print modifier for msghrd->…

### DIFF
--- a/src/test/scm_rights.c
+++ b/src/test/scm_rights.c
@@ -37,8 +37,8 @@ static void child(int sock, int fd_minus_one) {
   atomic_printf("c: receiving msg ...\n");
   nread = recvmsg(sock, &msg, 0);
 
-  atomic_printf("c:   ... got %#x (%zd bytes), %zu control bytes\n",
-                mbuf.ints[0], nread, msg.msg_controllen);
+  atomic_printf("c:   ... got %#x (%zd bytes), %ju control bytes\n",
+                mbuf.ints[0], nread, (uintmax_t)msg.msg_controllen);
   test_assert(nread == sizeof(mbuf.ints[0]));
   test_assert(MAGIC == mbuf.ints[0]);
   test_assert(~MAGIC == mbuf.ints[1]);


### PR DESCRIPTION
…controllen


The Linux Manpage says:

> According to POSIX.1-2001, the msg_controllen field of the msghdr structure should be typed as socklen_t, but glibc currently types it as size_t.

> `socklen_t`
Describes the length of a socket address.  This is an integer type of at least 32 bits.

So "unsigned int" as defined in Alpine is fine, but break the compilation because of the formatting.

The Debian manpage mentions:

> Most of the integer types described in this page don't have a corresponding length modifier for the printf(3) [...] families of functions. To print a value of an integer type that doesn't have a length modifier, it should be converted to intmax_t or uintmax_t by an explicit cast. [...]