### PR TITLE
only define htonl where missing

### DIFF
--- a/src/test/privileged_net_ioctl.c
+++ b/src/test/privileged_net_ioctl.c
@@ -25,7 +25,7 @@ void buf_put_attr(char** cur_buf_pos, uint16_t opt, void* data, size_t size) {
   *cur_buf_pos += RTA_ALIGN(size) - size;
 }
 
-#ifndef htonl
+#ifdef __ANDROID__
 #define htonl(x) __bswap_32(x)
 #endif
 


### PR DESCRIPTION
* glibc has that as a define
* muslc and others have that as a function
* Android API level 20 misses it